### PR TITLE
♻️  Refactor: 이미지 데이터 저장 로직 개선

### DIFF
--- a/src/main/java/com/likelion/backendplus4/yakplus/drug/application/service/port/out/DrugImageRepositoryPort.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/drug/application/service/port/out/DrugImageRepositoryPort.java
@@ -1,13 +1,11 @@
 package com.likelion.backendplus4.yakplus.drug.application.service.port.out;
 
 import java.util.List;
-import java.util.Optional;
 
 import com.likelion.backendplus4.yakplus.drug.domain.model.DrugImage;
-import com.likelion.backendplus4.yakplus.drug.infrastructure.adapter.persistence.repository.entity.ApiDataDrugImgEntity;
 
 public interface DrugImageRepositoryPort {
-	List<DrugImage> getAllGovDrugDetail();
+	List<DrugImage> getAllGovDrugImage();
 
 	DrugImage getById(Long drugId);
 

--- a/src/main/java/com/likelion/backendplus4/yakplus/drug/application/service/port/out/DrugImageRepositoryPort.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/drug/application/service/port/out/DrugImageRepositoryPort.java
@@ -10,4 +10,6 @@ public interface DrugImageRepositoryPort {
 	List<DrugImage> getAllGovDrugDetail();
 
 	DrugImage getById(Long drugId);
+
+	void saveAllAndFlush(List<DrugImage> imgData);
 }

--- a/src/main/java/com/likelion/backendplus4/yakplus/drug/application/service/scraper/image/DrugImageGovScraper.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/drug/application/service/scraper/image/DrugImageGovScraper.java
@@ -9,7 +9,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.likelion.backendplus4.yakplus.drug.application.service.port.out.ApiRequestPort;
-import com.likelion.backendplus4.yakplus.drug.infrastructure.adapter.persistence.repository.jpa.ApiDataDrugImgRepo;
+import com.likelion.backendplus4.yakplus.drug.application.service.port.out.DrugImageRepositoryPort;
+import com.likelion.backendplus4.yakplus.drug.domain.model.DrugImage;
 import com.likelion.backendplus4.yakplus.drug.infrastructure.adapter.persistence.repository.entity.ApiDataDrugImgEntity;
 
 import jakarta.transaction.Transactional;
@@ -21,21 +22,21 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class DrugImageGovScraper {
 	private final ApiRequestPort apiRequestPort;
-	private final ApiDataDrugImgRepo imgRepo;
+	private final DrugImageRepositoryPort drugImageRepositoryPort;
 	private final ObjectMapper objectMapper;
 
 	@Transactional
 	public void getApiData(){
 		log.info("의약품 개요 정보 API 호출 시작");
 		JsonNode items = apiRequestPort.getAllImageData(1);
-		List<ApiDataDrugImgEntity> imgDatas = null;
+		List<DrugImage> imgData = null;
 		try {
-			imgDatas = objectMapper.readValue(items.toString(),
-				new TypeReference<List<ApiDataDrugImgEntity>>() {});
+			imgData = objectMapper.readValue(items.toString(),
+				new TypeReference<List<DrugImage>>() {});
 		} catch (JsonProcessingException e) {
 			throw new RuntimeException(e);
 		}
-		imgRepo.saveAllAndFlush(imgDatas);
+		drugImageRepositoryPort.saveAllAndFlush(imgData);
 	}
 
 	public void getAllApiData(){
@@ -43,14 +44,14 @@ public class DrugImageGovScraper {
 		int totalPageCount = apiRequestPort.getImageTotalPageCount();
 		for(int i=1;i<=totalPageCount;i++){
 			JsonNode items = apiRequestPort.getAllImageData(i);
-			List<ApiDataDrugImgEntity> imgDatas = null;
+			List<DrugImage> imgData = null;
 			try {
-				imgDatas = objectMapper.readValue(items.toString(),
-					new TypeReference<List<ApiDataDrugImgEntity>>() {});
+				imgData = objectMapper.readValue(items.toString(),
+					new TypeReference<List<DrugImage>>() {});
 			} catch (JsonProcessingException e) {
 				throw new RuntimeException(e);
 			}
-			imgRepo.saveAllAndFlush(imgDatas);
+			drugImageRepositoryPort.saveAllAndFlush(imgData);
 		}
 	}
 

--- a/src/main/java/com/likelion/backendplus4/yakplus/drug/infrastructure/adapter/out/DrugImageRepositoryAdapter.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/drug/infrastructure/adapter/out/DrugImageRepositoryAdapter.java
@@ -20,7 +20,7 @@ public class DrugImageRepositoryAdapter implements DrugImageRepositoryPort {
 	private final ApiDataDrugImgRepo imageRepository;
 
 	@Override
-	public List<DrugImage> getAllGovDrugDetail(){
+	public List<DrugImage> getAllGovDrugImage(){
 		return imageRepository.findAll().stream()
 			.map(DrugImageMapper::toDomainFromEntity)
 			.collect(Collectors.toList());

--- a/src/main/java/com/likelion/backendplus4/yakplus/drug/infrastructure/adapter/out/DrugImageRepositoryAdapter.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/drug/infrastructure/adapter/out/DrugImageRepositoryAdapter.java
@@ -33,6 +33,12 @@ public class DrugImageRepositoryAdapter implements DrugImageRepositoryPort {
 			.orElseGet(() -> getDefaultDomain());
 	}
 
+	@Override
+	public void saveAllAndFlush(List<DrugImage> imgData) {
+		imageRepository.saveAll(DrugImageMapper.toEntityListFromDomainList(imgData));
+		imageRepository.flush();
+	}
+
 	private static DrugImage getDefaultDomain() {
 		return DrugImageMapper.toDomainFromEntity(new ApiDataDrugImgEntity());
 	}

--- a/src/main/java/com/likelion/backendplus4/yakplus/drug/infrastructure/adapter/persistence/repository/entity/ApiDataDrugImgEntity.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/drug/infrastructure/adapter/persistence/repository/entity/ApiDataDrugImgEntity.java
@@ -5,11 +5,17 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Entity
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @ToString
 @Table(name="API_DATA_DRUG_IMG")
 public class ApiDataDrugImgEntity {

--- a/src/main/java/com/likelion/backendplus4/yakplus/drug/infrastructure/support/mapper/DrugImageMapper.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/drug/infrastructure/support/mapper/DrugImageMapper.java
@@ -1,5 +1,7 @@
 package com.likelion.backendplus4.yakplus.drug.infrastructure.support.mapper;
 
+import java.util.List;
+
 import com.likelion.backendplus4.yakplus.drug.domain.model.DrugImage;
 import com.likelion.backendplus4.yakplus.drug.domain.model.GovDrugDetail;
 import com.likelion.backendplus4.yakplus.drug.infrastructure.adapter.persistence.repository.entity.ApiDataDrugImgEntity;
@@ -10,5 +12,20 @@ public class DrugImageMapper {
 			.drugId(e.getDrugId())
 			.imageUrl(e.getImgUrl())
 			.build();
+	}
+
+	public static ApiDataDrugImgEntity toEntityFromDomain(DrugImage d){
+		return ApiDataDrugImgEntity.builder()
+			.drugId(d.getDrugId())
+			.imgUrl(d.getImageUrl())
+			.build();
+	}
+
+	public static List<ApiDataDrugImgEntity> toEntityListFromDomainList(List<DrugImage> drugImageList) {
+		return drugImageList.stream().map(DrugImageMapper::toEntityFromDomain).toList();
+	}
+
+	public static List<DrugImage> toDomainListFromEntityList(List<ApiDataDrugImgEntity> drugImageEntityList) {
+		return drugImageEntityList.stream().map(DrugImageMapper::toDomainFromEntity).toList();
 	}
 }


### PR DESCRIPTION
-  https://github.com/yakplus/batch/blob/ffbc2fec6067c9019dd44922a69a8d59791333cc/src/main/java/com/likelion/backendplus4/yakplus/drug/application/service/scraper/image/DrugImageGovScraper.java#L23-L58  
1. jpa repository를 직접 접근하던 것을 DrugImageRepositoryPort를 통해 간접 접근하도록 수정 
 2. 접근타입 변경 (entity객체 접근 -> domain 객체 접근으로 변경) 으로 인한 typereference 및 list 타입 수정
- https://github.com/yakplus/batch/blob/ffbc2fec6067c9019dd44922a69a8d59791333cc/src/main/java/com/likelion/backendplus4/yakplus/drug/application/service/port/out/DrugImageRepositoryPort.java#L14  DrugImageRepositoryPort.java에서 saveAllAndFlush 함수 interface 추가
- https://github.com/yakplus/batch/blob/ffbc2fec6067c9019dd44922a69a8d59791333cc/src/main/java/com/likelion/backendplus4/yakplus/drug/infrastructure/adapter/out/DrugImageRepositoryAdapter.java#L36-L40  DrugImageRepositoryAdapter.java에서 saveAllAndFlush 함수 구현
-  https://github.com/yakplus/batch/blob/ffbc2fec6067c9019dd44922a69a8d59791333cc/src/main/java/com/likelion/backendplus4/yakplus/drug/infrastructure/support/mapper/DrugImageMapper.java#L24-L30  DrugImageMapper.java에서 단일 도메인 객체를 단일 엔티티로 변환하는 toEntityFromDomain함수와 리스트를 변환하는 toEntityListFromDomainList 함수 구현 

closes #23 