### PR TITLE
✨ Feat: 임베딩 포트 어뎁터 추가

### DIFF
--- a/src/main/java/com/likelion/backendplus4/yakplus/index/application/port/out/EmbeddingLoadingPort.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/index/application/port/out/EmbeddingLoadingPort.java
@@ -1,0 +1,9 @@
+package com.likelion.backendplus4.yakplus.index.application.port.out;
+
+import com.likelion.backendplus4.yakplus.drug.domain.model.Drug;
+
+import java.util.List;
+
+public interface EmbeddingLoadingPort {
+    List<Drug> loadAllEmbeddings();
+}

--- a/src/main/java/com/likelion/backendplus4/yakplus/index/infrastructure/adapter/persistence/DrugMapper.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/index/infrastructure/adapter/persistence/DrugMapper.java
@@ -1,0 +1,46 @@
+package com.likelion.backendplus4.yakplus.index.infrastructure.adapter.persistence;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.likelion.backendplus4.yakplus.drug.domain.model.vo.Material;
+
+import java.util.List;
+import java.util.Map;
+
+public class DrugMapper{
+    public static List<Material> parseMaterials(String json) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            return objectMapper.readValue(json, new TypeReference<List<Material>>() {});
+        } catch (Exception e) {
+            throw new RuntimeException("Material 파싱 실패", e);
+        }
+    }
+
+    public static List<String> parseStringToList(String json) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            return objectMapper.readValue(json, new TypeReference<List<String>>() {});
+        } catch (Exception e) {
+            throw new RuntimeException("String to list 파싱 실패", e);
+        }
+    }
+
+    public static Map<String, List<String>> parsePrecaution(String json) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            return objectMapper.readValue(json, new TypeReference<Map<String, List<String>>>() {});
+        } catch (Exception e) {
+            throw new RuntimeException("precaution 파싱 실패", e);
+        }
+    }
+
+    public static float[] parseJsonToFloatArray(String json) {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            return mapper.readValue(json, float[].class);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse vector JSON", e);
+        }
+    }
+}

--- a/src/main/java/com/likelion/backendplus4/yakplus/index/infrastructure/adapter/persistence/GptEmbeddingLoadingAdapter.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/index/infrastructure/adapter/persistence/GptEmbeddingLoadingAdapter.java
@@ -1,0 +1,104 @@
+package com.likelion.backendplus4.yakplus.index.infrastructure.adapter.persistence;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.likelion.backendplus4.yakplus.drug.domain.model.Drug;
+import com.likelion.backendplus4.yakplus.drug.domain.model.vo.Material;
+import com.likelion.backendplus4.yakplus.drug.infrastructure.adapter.persistence.repository.entity.DrugGptEmbedEntity;
+import com.likelion.backendplus4.yakplus.drug.infrastructure.adapter.persistence.repository.entity.DrugRawDataEntity;
+import com.likelion.backendplus4.yakplus.drug.infrastructure.adapter.persistence.repository.jpa.GovDrugGptEmbedJpaRepository;
+import com.likelion.backendplus4.yakplus.drug.infrastructure.adapter.persistence.repository.jpa.GovDrugJpaRepository;
+import com.likelion.backendplus4.yakplus.index.application.port.out.EmbeddingLoadingPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Repository
+@RequiredArgsConstructor
+@Qualifier("gptAdapter")
+public class GptEmbeddingLoadingAdapter implements EmbeddingLoadingPort {
+    private final GovDrugGptEmbedJpaRepository govDrugGptEmbedJpaRepository;
+    private final GovDrugJpaRepository govDrugJpaRepository;
+
+
+    @Override
+    public List<Drug> loadAllEmbeddings() {
+        List<DrugRawDataEntity> rawDataEntities = govDrugJpaRepository.findAll();
+        List<DrugGptEmbedEntity> drugGptEmbedEntities = govDrugGptEmbedJpaRepository.findAll();
+
+        // drugGptEmbedEntities를 Map으로 변환 (key: drugId)
+        Map<Long, DrugGptEmbedEntity> gptEmbedMap = new HashMap<>();
+        for (DrugGptEmbedEntity embed : drugGptEmbedEntities) {
+            gptEmbedMap.put(embed.getDrugId(), embed);
+        }
+
+        List<Drug> drugs = new ArrayList<>();
+        for (DrugRawDataEntity drugRawData : rawDataEntities) {
+            DrugGptEmbedEntity embed = gptEmbedMap.get(drugRawData.getDrugId());
+            Drug drug = toDomainFromEntity(drugRawData, embed);
+            drugs.add(drug);
+        }
+
+        return drugs;
+    }
+
+    private static Drug toDomainFromEntity(DrugRawDataEntity drugEntity, DrugGptEmbedEntity embedEntity) {
+        return Drug.builder()
+                .drugId(drugEntity.getDrugId())
+                .drugName(drugEntity.getDrugName())
+                .company(drugEntity.getCompany())
+                .permitDate(drugEntity.getPermitDate())
+                .isGeneral(drugEntity.isGeneral())
+                .materialInfo(parseMaterials(drugEntity.getMaterialInfo()))
+                .storeMethod(drugEntity.getStoreMethod())
+                .validTerm(drugEntity.getValidTerm())
+                .efficacy(parseStringToList(drugEntity.getEfficacy()))
+                .usage(parseStringToList(drugEntity.getUsage()))
+                .precaution(parsePrecaution(drugEntity.getPrecaution()))
+                .imageUrl(drugEntity.getImageUrl())
+                .vector(parseJsonToFloatArray(embedEntity.getGptVector()))
+                .build();
+    }
+
+    public static List<Material> parseMaterials(String json) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            return objectMapper.readValue(json, new TypeReference<List<Material>>() {});
+        } catch (Exception e) {
+            throw new RuntimeException("Material 파싱 실패", e);
+        }
+    }
+
+    public static List<String> parseStringToList(String json) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            return objectMapper.readValue(json, new TypeReference<List<String>>() {});
+        } catch (Exception e) {
+            throw new RuntimeException("String to list 파싱 실패", e);
+        }
+    }
+
+    public static Map<String, List<String>> parsePrecaution(String json) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            return objectMapper.readValue(json, new TypeReference<Map<String, List<String>>>() {});
+        } catch (Exception e) {
+            throw new RuntimeException("precaution 파싱 실패", e);
+        }
+    }
+
+    public static float[] parseJsonToFloatArray(String json) {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            return mapper.readValue(json, float[].class);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse vector JSON", e);
+        }
+    }
+
+}

--- a/src/main/java/com/likelion/backendplus4/yakplus/index/infrastructure/adapter/persistence/GptEmbeddingLoadingAdapter.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/index/infrastructure/adapter/persistence/GptEmbeddingLoadingAdapter.java
@@ -54,51 +54,17 @@ public class GptEmbeddingLoadingAdapter implements EmbeddingLoadingPort {
                 .company(drugEntity.getCompany())
                 .permitDate(drugEntity.getPermitDate())
                 .isGeneral(drugEntity.isGeneral())
-                .materialInfo(parseMaterials(drugEntity.getMaterialInfo()))
+                .materialInfo(DrugMapper.parseMaterials(drugEntity.getMaterialInfo()))
                 .storeMethod(drugEntity.getStoreMethod())
                 .validTerm(drugEntity.getValidTerm())
-                .efficacy(parseStringToList(drugEntity.getEfficacy()))
-                .usage(parseStringToList(drugEntity.getUsage()))
-                .precaution(parsePrecaution(drugEntity.getPrecaution()))
+                .efficacy(DrugMapper.parseStringToList(drugEntity.getEfficacy()))
+                .usage(DrugMapper.parseStringToList(drugEntity.getUsage()))
+                .precaution(DrugMapper.parsePrecaution(drugEntity.getPrecaution()))
                 .imageUrl(drugEntity.getImageUrl())
-                .vector(parseJsonToFloatArray(embedEntity.getGptVector()))
+                .vector(DrugMapper.parseJsonToFloatArray(embedEntity.getGptVector()))
                 .build();
     }
 
-    public static List<Material> parseMaterials(String json) {
-        try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            return objectMapper.readValue(json, new TypeReference<List<Material>>() {});
-        } catch (Exception e) {
-            throw new RuntimeException("Material 파싱 실패", e);
-        }
-    }
 
-    public static List<String> parseStringToList(String json) {
-        try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            return objectMapper.readValue(json, new TypeReference<List<String>>() {});
-        } catch (Exception e) {
-            throw new RuntimeException("String to list 파싱 실패", e);
-        }
-    }
-
-    public static Map<String, List<String>> parsePrecaution(String json) {
-        try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            return objectMapper.readValue(json, new TypeReference<Map<String, List<String>>>() {});
-        } catch (Exception e) {
-            throw new RuntimeException("precaution 파싱 실패", e);
-        }
-    }
-
-    public static float[] parseJsonToFloatArray(String json) {
-        try {
-            ObjectMapper mapper = new ObjectMapper();
-            return mapper.readValue(json, float[].class);
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to parse vector JSON", e);
-        }
-    }
 
 }

--- a/src/main/java/com/likelion/backendplus4/yakplus/index/infrastructure/adapter/persistence/KmBertEmbeddingLoadingAdapter.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/index/infrastructure/adapter/persistence/KmBertEmbeddingLoadingAdapter.java
@@ -1,0 +1,104 @@
+package com.likelion.backendplus4.yakplus.index.infrastructure.adapter.persistence;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.likelion.backendplus4.yakplus.drug.domain.model.Drug;
+import com.likelion.backendplus4.yakplus.drug.domain.model.vo.Material;
+import com.likelion.backendplus4.yakplus.drug.infrastructure.adapter.persistence.repository.entity.DrugKmBertEmbedEntity;
+import com.likelion.backendplus4.yakplus.drug.infrastructure.adapter.persistence.repository.entity.DrugRawDataEntity;
+import com.likelion.backendplus4.yakplus.drug.infrastructure.adapter.persistence.repository.jpa.GovDrugJpaRepository;
+import com.likelion.backendplus4.yakplus.drug.infrastructure.adapter.persistence.repository.jpa.GovDrugKmBertEmbedJpaRepository;
+import com.likelion.backendplus4.yakplus.index.application.port.out.EmbeddingLoadingPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Repository
+@RequiredArgsConstructor
+@Qualifier("kmBertAdapter")
+public class KmBertEmbeddingLoadingAdapter implements EmbeddingLoadingPort {
+    private final GovDrugKmBertEmbedJpaRepository govDrugKmBertEmbedJpaRepository;
+    private final GovDrugJpaRepository govDrugJpaRepository;
+
+
+    @Override
+    public List<Drug> loadAllEmbeddings() {
+        List<DrugRawDataEntity> rawDataEntities = govDrugJpaRepository.findAll();
+        List<DrugKmBertEmbedEntity> drugKmBertEmbedEntities = govDrugKmBertEmbedJpaRepository.findAll();
+
+        // drugKmBertEmbedEntities를 Map으로 변환 (key: drugId)
+        Map<Long, DrugKmBertEmbedEntity> kmBertEmbedMap = new HashMap<>();
+        for (DrugKmBertEmbedEntity embed : drugKmBertEmbedEntities) {
+            kmBertEmbedMap.put(embed.getDrugId(), embed);
+        }
+
+        List<Drug> drugs = new ArrayList<>();
+        for (DrugRawDataEntity drugRawData : rawDataEntities) {
+            DrugKmBertEmbedEntity embed = kmBertEmbedMap.get(drugRawData.getDrugId());
+            Drug drug = toDomainFromEntity(drugRawData, embed);
+            drugs.add(drug);
+        }
+
+        return drugs;
+    }
+
+    private static Drug toDomainFromEntity(DrugRawDataEntity drugEntity, DrugKmBertEmbedEntity embedEntity) {
+        return Drug.builder()
+                .drugId(drugEntity.getDrugId())
+                .drugName(drugEntity.getDrugName())
+                .company(drugEntity.getCompany())
+                .permitDate(drugEntity.getPermitDate())
+                .isGeneral(drugEntity.isGeneral())
+                .materialInfo(parseMaterials(drugEntity.getMaterialInfo()))
+                .storeMethod(drugEntity.getStoreMethod())
+                .validTerm(drugEntity.getValidTerm())
+                .efficacy(parseStringToList(drugEntity.getEfficacy()))
+                .usage(parseStringToList(drugEntity.getUsage()))
+                .precaution(parsePrecaution(drugEntity.getPrecaution()))
+                .imageUrl(drugEntity.getImageUrl())
+                .vector(parseJsonToFloatArray(embedEntity.getKmBertVector()))
+                .build();
+    }
+
+    public static List<Material> parseMaterials(String json) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            return objectMapper.readValue(json, new TypeReference<List<Material>>() {});
+        } catch (Exception e) {
+            throw new RuntimeException("Material 파싱 실패", e);
+        }
+    }
+
+    public static List<String> parseStringToList(String json) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            return objectMapper.readValue(json, new TypeReference<List<String>>() {});
+        } catch (Exception e) {
+            throw new RuntimeException("String to list 파싱 실패", e);
+        }
+    }
+
+    public static Map<String, List<String>> parsePrecaution(String json) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            return objectMapper.readValue(json, new TypeReference<Map<String, List<String>>>() {});
+        } catch (Exception e) {
+            throw new RuntimeException("precaution 파싱 실패", e);
+        }
+    }
+
+    public static float[] parseJsonToFloatArray(String json) {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            return mapper.readValue(json, float[].class);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse vector JSON", e);
+        }
+    }
+
+}

--- a/src/main/java/com/likelion/backendplus4/yakplus/index/infrastructure/adapter/persistence/KmBertEmbeddingLoadingAdapter.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/index/infrastructure/adapter/persistence/KmBertEmbeddingLoadingAdapter.java
@@ -54,51 +54,15 @@ public class KmBertEmbeddingLoadingAdapter implements EmbeddingLoadingPort {
                 .company(drugEntity.getCompany())
                 .permitDate(drugEntity.getPermitDate())
                 .isGeneral(drugEntity.isGeneral())
-                .materialInfo(parseMaterials(drugEntity.getMaterialInfo()))
+                .materialInfo(DrugMapper.parseMaterials(drugEntity.getMaterialInfo()))
                 .storeMethod(drugEntity.getStoreMethod())
                 .validTerm(drugEntity.getValidTerm())
-                .efficacy(parseStringToList(drugEntity.getEfficacy()))
-                .usage(parseStringToList(drugEntity.getUsage()))
-                .precaution(parsePrecaution(drugEntity.getPrecaution()))
+                .efficacy(DrugMapper.parseStringToList(drugEntity.getEfficacy()))
+                .usage(DrugMapper.parseStringToList(drugEntity.getUsage()))
+                .precaution(DrugMapper.parsePrecaution(drugEntity.getPrecaution()))
                 .imageUrl(drugEntity.getImageUrl())
-                .vector(parseJsonToFloatArray(embedEntity.getKmBertVector()))
+                .vector(DrugMapper.parseJsonToFloatArray(embedEntity.getKmBertVector()))
                 .build();
-    }
-
-    public static List<Material> parseMaterials(String json) {
-        try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            return objectMapper.readValue(json, new TypeReference<List<Material>>() {});
-        } catch (Exception e) {
-            throw new RuntimeException("Material 파싱 실패", e);
-        }
-    }
-
-    public static List<String> parseStringToList(String json) {
-        try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            return objectMapper.readValue(json, new TypeReference<List<String>>() {});
-        } catch (Exception e) {
-            throw new RuntimeException("String to list 파싱 실패", e);
-        }
-    }
-
-    public static Map<String, List<String>> parsePrecaution(String json) {
-        try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            return objectMapper.readValue(json, new TypeReference<Map<String, List<String>>>() {});
-        } catch (Exception e) {
-            throw new RuntimeException("precaution 파싱 실패", e);
-        }
-    }
-
-    public static float[] parseJsonToFloatArray(String json) {
-        try {
-            ObjectMapper mapper = new ObjectMapper();
-            return mapper.readValue(json, float[].class);
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to parse vector JSON", e);
-        }
     }
 
 }

--- a/src/main/java/com/likelion/backendplus4/yakplus/index/infrastructure/adapter/persistence/KrSBertEmbeddingLoadingAdapter.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/index/infrastructure/adapter/persistence/KrSBertEmbeddingLoadingAdapter.java
@@ -1,0 +1,104 @@
+package com.likelion.backendplus4.yakplus.index.infrastructure.adapter.persistence;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.likelion.backendplus4.yakplus.drug.domain.model.Drug;
+import com.likelion.backendplus4.yakplus.drug.domain.model.vo.Material;
+import com.likelion.backendplus4.yakplus.drug.infrastructure.adapter.persistence.repository.entity.DrugKrSbertEmbedEntity;
+import com.likelion.backendplus4.yakplus.drug.infrastructure.adapter.persistence.repository.entity.DrugRawDataEntity;
+import com.likelion.backendplus4.yakplus.drug.infrastructure.adapter.persistence.repository.jpa.GovDrugJpaRepository;
+import com.likelion.backendplus4.yakplus.drug.infrastructure.adapter.persistence.repository.jpa.GovDrugKrSbertEmbedJpaRepository;
+import com.likelion.backendplus4.yakplus.index.application.port.out.EmbeddingLoadingPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Repository
+@RequiredArgsConstructor
+@Qualifier("krSBertAdapter")
+public class KrSBertEmbeddingLoadingAdapter implements EmbeddingLoadingPort {
+    private final GovDrugKrSbertEmbedJpaRepository govDrugKrSbertEmbedJpaRepository;
+    private final GovDrugJpaRepository govDrugJpaRepository;
+
+
+    @Override
+    public List<Drug> loadAllEmbeddings() {
+        List<DrugRawDataEntity> rawDataEntities = govDrugJpaRepository.findAll();
+        List<DrugKrSbertEmbedEntity> drugKrSBertEmbedEntities = govDrugKrSbertEmbedJpaRepository.findAll();
+
+        // drugKmBertEmbedEntities를 Map으로 변환 (key: drugId)
+        Map<Long, DrugKrSbertEmbedEntity> krSBertEmbedMap = new HashMap<>();
+        for (DrugKrSbertEmbedEntity embed : drugKrSBertEmbedEntities) {
+            krSBertEmbedMap.put(embed.getDrugId(), embed);
+        }
+
+        List<Drug> drugs = new ArrayList<>();
+        for (DrugRawDataEntity drugRawData : rawDataEntities) {
+            DrugKrSbertEmbedEntity embed = krSBertEmbedMap.get(drugRawData.getDrugId());
+            Drug drug = toDomainFromEntity(drugRawData, embed);
+            drugs.add(drug);
+        }
+
+        return drugs;
+    }
+
+    private static Drug toDomainFromEntity(DrugRawDataEntity drugEntity, DrugKrSbertEmbedEntity embedEntity) {
+        return Drug.builder()
+                .drugId(drugEntity.getDrugId())
+                .drugName(drugEntity.getDrugName())
+                .company(drugEntity.getCompany())
+                .permitDate(drugEntity.getPermitDate())
+                .isGeneral(drugEntity.isGeneral())
+                .materialInfo(parseMaterials(drugEntity.getMaterialInfo()))
+                .storeMethod(drugEntity.getStoreMethod())
+                .validTerm(drugEntity.getValidTerm())
+                .efficacy(parseStringToList(drugEntity.getEfficacy()))
+                .usage(parseStringToList(drugEntity.getUsage()))
+                .precaution(parsePrecaution(drugEntity.getPrecaution()))
+                .imageUrl(drugEntity.getImageUrl())
+                .vector(parseJsonToFloatArray(embedEntity.getKrSbertVector()))
+                .build();
+    }
+
+    public static List<Material> parseMaterials(String json) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            return objectMapper.readValue(json, new TypeReference<List<Material>>() {});
+        } catch (Exception e) {
+            throw new RuntimeException("Material 파싱 실패", e);
+        }
+    }
+
+    public static List<String> parseStringToList(String json) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            return objectMapper.readValue(json, new TypeReference<List<String>>() {});
+        } catch (Exception e) {
+            throw new RuntimeException("String to list 파싱 실패", e);
+        }
+    }
+
+    public static Map<String, List<String>> parsePrecaution(String json) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            return objectMapper.readValue(json, new TypeReference<Map<String, List<String>>>() {});
+        } catch (Exception e) {
+            throw new RuntimeException("precaution 파싱 실패", e);
+        }
+    }
+
+    public static float[] parseJsonToFloatArray(String json) {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            return mapper.readValue(json, float[].class);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse vector JSON", e);
+        }
+    }
+
+}

--- a/src/main/java/com/likelion/backendplus4/yakplus/index/infrastructure/adapter/persistence/KrSBertEmbeddingLoadingAdapter.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/index/infrastructure/adapter/persistence/KrSBertEmbeddingLoadingAdapter.java
@@ -31,7 +31,7 @@ public class KrSBertEmbeddingLoadingAdapter implements EmbeddingLoadingPort {
         List<DrugRawDataEntity> rawDataEntities = govDrugJpaRepository.findAll();
         List<DrugKrSbertEmbedEntity> drugKrSBertEmbedEntities = govDrugKrSbertEmbedJpaRepository.findAll();
 
-        // drugKmBertEmbedEntities를 Map으로 변환 (key: drugId)
+        // drugKrSBertEmbedEntities를 Map으로 변환 (key: drugId)
         Map<Long, DrugKrSbertEmbedEntity> krSBertEmbedMap = new HashMap<>();
         for (DrugKrSbertEmbedEntity embed : drugKrSBertEmbedEntities) {
             krSBertEmbedMap.put(embed.getDrugId(), embed);
@@ -54,51 +54,15 @@ public class KrSBertEmbeddingLoadingAdapter implements EmbeddingLoadingPort {
                 .company(drugEntity.getCompany())
                 .permitDate(drugEntity.getPermitDate())
                 .isGeneral(drugEntity.isGeneral())
-                .materialInfo(parseMaterials(drugEntity.getMaterialInfo()))
+                .materialInfo(DrugMapper.parseMaterials(drugEntity.getMaterialInfo()))
                 .storeMethod(drugEntity.getStoreMethod())
                 .validTerm(drugEntity.getValidTerm())
-                .efficacy(parseStringToList(drugEntity.getEfficacy()))
-                .usage(parseStringToList(drugEntity.getUsage()))
-                .precaution(parsePrecaution(drugEntity.getPrecaution()))
+                .efficacy(DrugMapper.parseStringToList(drugEntity.getEfficacy()))
+                .usage(DrugMapper.parseStringToList(drugEntity.getUsage()))
+                .precaution(DrugMapper.parsePrecaution(drugEntity.getPrecaution()))
                 .imageUrl(drugEntity.getImageUrl())
-                .vector(parseJsonToFloatArray(embedEntity.getKrSbertVector()))
+                .vector(DrugMapper.parseJsonToFloatArray(embedEntity.getKrSbertVector()))
                 .build();
-    }
-
-    public static List<Material> parseMaterials(String json) {
-        try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            return objectMapper.readValue(json, new TypeReference<List<Material>>() {});
-        } catch (Exception e) {
-            throw new RuntimeException("Material 파싱 실패", e);
-        }
-    }
-
-    public static List<String> parseStringToList(String json) {
-        try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            return objectMapper.readValue(json, new TypeReference<List<String>>() {});
-        } catch (Exception e) {
-            throw new RuntimeException("String to list 파싱 실패", e);
-        }
-    }
-
-    public static Map<String, List<String>> parsePrecaution(String json) {
-        try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            return objectMapper.readValue(json, new TypeReference<Map<String, List<String>>>() {});
-        } catch (Exception e) {
-            throw new RuntimeException("precaution 파싱 실패", e);
-        }
-    }
-
-    public static float[] parseJsonToFloatArray(String json) {
-        try {
-            ObjectMapper mapper = new ObjectMapper();
-            return mapper.readValue(json, float[].class);
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to parse vector JSON", e);
-        }
     }
 
 }


### PR DESCRIPTION
임베딩 결과 조회용 port 생성

임베딩 모델 3개를 위한 adapter 내용작성

https://github.com/yakplus/batch/blob/6d8bd8e9d22f7e66b7b821d0d4a3ec176fd32b41/src/main/java/com/likelion/backendplus4/yakplus/index/infrastructure/adapter/persistence/DrugMapper.java#L11-L45

string 형태로 받아와지는 아래 4필드 + 벡터 

private List<Material> materialInfo;
private List<String> efficacy;
private List<String> usage;
private Map<String, List<String>> precaution;
private float[] vector;

별도로 파싱하는 로직입니다. 혹시 문제가 될 것 같은 부분 보이시면 멘트 부탁드립니다.

