### PR TITLE
🐛  Bug: es인덱싱 이미지url null 값처리

### DIFF
--- a/src/main/java/com/likelion/backendplus4/yakplus/index/application/service/DrugIndexer.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/index/application/service/DrugIndexer.java
@@ -1,5 +1,6 @@
 package com.likelion.backendplus4.yakplus.index.application.service;
 
+import com.likelion.backendplus4.yakplus.common.util.log.LogLevel;
 import com.likelion.backendplus4.yakplus.drug.domain.model.Drug;
 import com.likelion.backendplus4.yakplus.index.application.port.in.IndexUseCase;
 import com.likelion.backendplus4.yakplus.index.application.port.out.DrugIndexRepositoryPort;
@@ -46,11 +47,16 @@ public class DrugIndexer implements IndexUseCase {
     public void index() {
         log("index 서비스 요청 수신");
 //        Pageable pageable = createPageable(request.limit());
-        for (int i = 1; i <= 50; i++) {
-            List<Drug> drugs = fetchRawData(i);
-            String esIndexName = getEsIndexName();
-            saveDrugs(esIndexName, drugs);
+        try {
+            for (int i = 1; i <= 50; i++) {
+                List<Drug> drugs = fetchRawData(i);
+                String esIndexName = getEsIndexName();
+                saveDrugs(esIndexName, drugs);
+            }
+        } catch (Exception e) {
+            log(LogLevel.ERROR,"indexing 시 데이터 5000개 보다 적어서 에러 발생 (데이터 5000개 이하면 전체 동작)", e);
         }
+
     }
 
     /**

--- a/src/main/java/com/likelion/backendplus4/yakplus/index/infrastructure/adapter/persistence/ElasticsearchDrugAdapter.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/index/infrastructure/adapter/persistence/ElasticsearchDrugAdapter.java
@@ -132,6 +132,6 @@ public class ElasticsearchDrugAdapter implements DrugIndexRepositoryPort {
      * @since 2025-04-22
      */
     private Map<String, Object> createDrugDocument(Drug drug) {
-        return Map.of("drugId", drug.getDrugId(), "drugName", drug.getDrugName(), "company", drug.getCompany(), "efficacy", drug.getEfficacy(), "imageUrl", drug.getImageUrl(), "vector", drug.getVector());
+        return Map.of("drugId", drug.getDrugId(), "drugName", drug.getDrugName(), "company", drug.getCompany(), "efficacy", drug.getEfficacy(), "imageUrl", drug.getImageUrl() != null ? drug.getImageUrl() : "", "vector", drug.getVector());
     }
 }


### PR DESCRIPTION
ElasticSearchDrugAdapter의 createDrugDocument에서 es인덱싱 이미지url이 null 값이면, 공백을 삽입하도록 처리.
인덱싱 요청 시, for문의 페이지보다 데이터량이 적으면, catch해서 예외 던지지 않도록 수정

작업 내용

1. ElasticSearchDrugAdapter의 createDrugDocument에서 es인덱싱 이미지url이 null 값이면, 공백을 삽입하도록 처리.

2. 인덱싱 요청 시, DrugIndexer의 index 함수에서 for문의 페이지보다 데이터량이 적으면, catch해서 예외 던지지 않도록 수정