### PR TITLE
♻️  Refactor: 임베딩 어뎁터 동작 수정

### DIFF
--- a/src/main/java/com/likelion/backendplus4/yakplus/drug/infrastructure/persistence/repository/jpa/GovDrugGptEmbedJpaRepository.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/drug/infrastructure/persistence/repository/jpa/GovDrugGptEmbedJpaRepository.java
@@ -1,10 +1,24 @@
 package com.likelion.backendplus4.yakplus.drug.infrastructure.persistence.repository.jpa;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.likelion.backendplus4.yakplus.drug.infrastructure.persistence.repository.entity.DrugGptEmbedEntity;
 
+import java.util.List;
+
 @Repository
 public interface GovDrugGptEmbedJpaRepository extends JpaRepository<DrugGptEmbedEntity,Long> {
+    @Query(
+            value = """
+            SELECT r, e
+            FROM DrugGptEmbedEntity e
+            JOIN DrugRawDataEntity  r
+                ON r.drugId = e.drugId
+            WHERE e.gptVector IS NOT NULL
+        """
+    )
+    List<Object[]> findRawAndEmbed(Pageable pageable);
 }

--- a/src/main/java/com/likelion/backendplus4/yakplus/drug/infrastructure/persistence/repository/jpa/GovDrugKmBertEmbedJpaRepository.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/drug/infrastructure/persistence/repository/jpa/GovDrugKmBertEmbedJpaRepository.java
@@ -1,10 +1,24 @@
 package com.likelion.backendplus4.yakplus.drug.infrastructure.persistence.repository.jpa;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.likelion.backendplus4.yakplus.drug.infrastructure.persistence.repository.entity.DrugKmBertEmbedEntity;
 
+import java.util.List;
+
 @Repository
 public interface GovDrugKmBertEmbedJpaRepository extends JpaRepository<DrugKmBertEmbedEntity,Long> {
+    @Query(
+            value = """
+            SELECT r, e
+            FROM DrugKmBertEmbedEntity e
+            JOIN DrugRawDataEntity  r
+                ON r.drugId = e.drugId
+            WHERE e.kmBertVector IS NOT NULL
+        """
+    )
+    List<Object[]> findRawAndEmbed(Pageable pageable);
 }

--- a/src/main/java/com/likelion/backendplus4/yakplus/drug/infrastructure/persistence/repository/jpa/GovDrugKrSbertEmbedJpaRepository.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/drug/infrastructure/persistence/repository/jpa/GovDrugKrSbertEmbedJpaRepository.java
@@ -1,10 +1,24 @@
 package com.likelion.backendplus4.yakplus.drug.infrastructure.persistence.repository.jpa;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.likelion.backendplus4.yakplus.drug.infrastructure.persistence.repository.entity.DrugKrSbertEmbedEntity;
 
+import java.util.List;
+
 @Repository
 public interface GovDrugKrSbertEmbedJpaRepository extends JpaRepository<DrugKrSbertEmbedEntity,Long> {
+    @Query(
+            value = """
+            SELECT r, e
+            FROM DrugKrSbertEmbedEntity e
+            JOIN DrugRawDataEntity  r
+                ON r.drugId = e.drugId
+            WHERE e.krSbertVector IS NOT NULL
+        """
+    )
+    List<Object[]> findRawAndEmbed(Pageable pageable);
 }

--- a/src/main/java/com/likelion/backendplus4/yakplus/index/application/port/out/GovDrugRawDataPort.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/index/application/port/out/GovDrugRawDataPort.java
@@ -9,8 +9,6 @@ import java.util.List;
 public interface GovDrugRawDataPort {
     List<Drug> fetchRawData(int i);
 
-    String getEsIndexName();
-
     Page<Drug> findAllDrugs(Pageable pageable);
 
 }

--- a/src/main/java/com/likelion/backendplus4/yakplus/index/application/service/DrugIndexer.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/index/application/service/DrugIndexer.java
@@ -5,6 +5,7 @@ import com.likelion.backendplus4.yakplus.drug.domain.model.Drug;
 import com.likelion.backendplus4.yakplus.index.application.port.in.IndexUseCase;
 import com.likelion.backendplus4.yakplus.index.application.port.out.DrugIndexRepositoryPort;
 import com.likelion.backendplus4.yakplus.index.application.port.out.GovDrugRawDataPort;
+import com.likelion.backendplus4.yakplus.switcher.application.port.out.EmbeddingSwitchPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -30,6 +31,7 @@ import static com.likelion.backendplus4.yakplus.common.util.log.LogUtil.log;
 public class DrugIndexer implements IndexUseCase {
     private final GovDrugRawDataPort govDrugRawDataPort;
     private final DrugIndexRepositoryPort drugIndexRepositoryPort;
+    private final EmbeddingSwitchPort embeddingSwitchPort;
     private static final String SORT_BY_PROPERTY = "drugId";
     private static final int CHUNK_SIZE = 1_000;
 
@@ -127,10 +129,13 @@ public class DrugIndexer implements IndexUseCase {
      * @return Elasticsearch 인덱스 이름
      * @author 정안식
      * @since 2025-04-27
+     * @modified 2025-05-02 이해창<br/>
+     * 2025-05-02 - 하드코딩 된 문자를 받어오던 것을
+     * 임베딩 모델 BeanName을 가져오도록 수정
      */
     private String getEsIndexName() {
         log("ES 인덱스 이름 조회");
-        return govDrugRawDataPort.getEsIndexName();
+        return embeddingSwitchPort.getAdapterBeanName();
     }
 
     /**

--- a/src/main/java/com/likelion/backendplus4/yakplus/index/infrastructure/adapter/persistence/GovDrugRawDataAdapter.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/index/infrastructure/adapter/persistence/GovDrugRawDataAdapter.java
@@ -35,16 +35,11 @@ import java.util.stream.Collectors;
 public class GovDrugRawDataAdapter implements GovDrugRawDataPort {
     private final GovDrugDetailJpaRepository rawDataJpaRepository;
     private final GovDrugJpaRepository drugJpaRepository;
-
     private final EmbeddingLoadingPort embeddingLoadingPort;
 
     @Value("${gov.numOfRows}")
     private int numOfRows;
 
-    @Override
-    public String getEsIndexName() {
-        return "test-gpt";
-    }
 
 
     /**
@@ -145,6 +140,6 @@ public class GovDrugRawDataAdapter implements GovDrugRawDataPort {
 
     private Pageable createPageable(int pageNo) {
         log("pageable 생성");
-        return PageRequest.of(pageNo-1, numOfRows, Sort.by(Sort.Direction.ASC, "drugId"));
+        return PageRequest.of(pageNo, numOfRows, Sort.by(Sort.Direction.ASC, "drugId"));
     }
 }

--- a/src/main/java/com/likelion/backendplus4/yakplus/index/infrastructure/adapter/persistence/GptEmbeddingLoadingAdapter.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/index/infrastructure/adapter/persistence/GptEmbeddingLoadingAdapter.java
@@ -1,11 +1,14 @@
 package com.likelion.backendplus4.yakplus.index.infrastructure.adapter.persistence;
 
+import com.likelion.backendplus4.yakplus.common.util.log.LogLevel;
 import com.likelion.backendplus4.yakplus.drug.domain.model.Drug;
 import com.likelion.backendplus4.yakplus.drug.infrastructure.persistence.repository.entity.DrugGptEmbedEntity;
 import com.likelion.backendplus4.yakplus.drug.infrastructure.persistence.repository.entity.DrugRawDataEntity;
 import com.likelion.backendplus4.yakplus.drug.infrastructure.persistence.repository.jpa.GovDrugGptEmbedJpaRepository;
 import com.likelion.backendplus4.yakplus.drug.infrastructure.persistence.repository.jpa.GovDrugJpaRepository;
 import com.likelion.backendplus4.yakplus.index.application.port.out.EmbeddingLoadingPort;
+import com.likelion.backendplus4.yakplus.index.exception.IndexException;
+import com.likelion.backendplus4.yakplus.index.exception.error.IndexErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.domain.Pageable;
@@ -22,33 +25,20 @@ import static com.likelion.backendplus4.yakplus.common.util.log.LogUtil.log;
 @RequiredArgsConstructor
 public class GptEmbeddingLoadingAdapter implements EmbeddingLoadingPort {
     private final GovDrugGptEmbedJpaRepository govDrugGptEmbedJpaRepository;
-    private final GovDrugJpaRepository govDrugJpaRepository;
 
     @Override
     public List<Drug> loadEmbeddingsByPage(Pageable pageable) {
-        List<DrugRawDataEntity> rawDataEntities = govDrugJpaRepository.findAll(pageable).getContent();
-        List<DrugGptEmbedEntity> drugGptEmbedEntities = govDrugGptEmbedJpaRepository.findAll(pageable).getContent();
-        log("loadEmbeddingsByPage - " + pageable.getPageNumber() +"페이지 에서 받아온 drug 상세정보 수: " + rawDataEntities.size());
-        log("loadEmbeddingsByPage - " + pageable.getPageNumber() +"페이지 에서 받아온 drug 임베딩 벡터수: " + drugGptEmbedEntities.size());
-
-        // drugGptEmbedEntities를 Map으로 변환 (key: drugId)
-        Map<Long, DrugGptEmbedEntity> gptEmbedMap = new HashMap<>();
-        for (DrugGptEmbedEntity embed : drugGptEmbedEntities) {
-            log("loadEmbeddingsByPage - " +pageable.getPageNumber()+"페이지에서 임베딩 벡터 받아온 약품 ID: " + embed.getDrugId());
-            gptEmbedMap.put(embed.getDrugId(), embed);
-        }
-
         List<Drug> drugs = new ArrayList<>();
-        log("loadEmbeddingsByPage - Drug 도메인 객체 생성 시작");
-        for (DrugRawDataEntity drugRawData : rawDataEntities) {
-            DrugGptEmbedEntity embed = gptEmbedMap.get(drugRawData.getDrugId());
-            if(embed == null) {
-                log("loadEmbeddingsByPage - " + "Drug 도메인 객체 생성 대상 " + drugRawData.getDrugId() + "의 벡터가 없으므로 skip");
-                continue;
-            }
-            log("loadEmbeddingsByPage - Drug 도메인 객체 생성 대상 " + drugRawData.getDrugId() + "의 벡터 길이: " + embed.getGptVector().length());
-            Drug drug = toDomainFromEntity(drugRawData, embed);
-            drugs.add(drug);
+        List<Object[]> rows = govDrugGptEmbedJpaRepository.findRawAndEmbed(pageable);
+        log("loadEmbeddingsByPage - " + pageable.getPageNumber() +"페이지 에서 받아온 drug 객체 제작 대상 데이터 수: " + rows.size());
+        if (rows.isEmpty()) {
+            log(LogLevel.ERROR,"loadEmbeddingsByPage - Drug 도메인 객체 생성 대상 데이터 없음");
+            throw new IndexException(IndexErrorCode.RAW_DATA_FETCH_ERROR);
+        }
+        for (Object[] arr : rows) {
+            DrugRawDataEntity   raw   = (DrugRawDataEntity)   arr[0];
+            DrugGptEmbedEntity  embed = (DrugGptEmbedEntity)  arr[1];
+            drugs.add(toDomainFromEntity(raw, embed));
         }
         log("loadEmbeddingsByPage - Drug 도메인 객체 생성 완료");
         return drugs;
@@ -68,6 +58,9 @@ public class GptEmbeddingLoadingAdapter implements EmbeddingLoadingPort {
                 .usage(DrugMapper.parseStringToList(drugEntity.getUsage()))
                 .precaution(DrugMapper.parsePrecaution(drugEntity.getPrecaution()))
                 .imageUrl(drugEntity.getImageUrl())
+                .cancelDate(drugEntity.getCancelDate())
+			    .cancelName(drugEntity.getCancelName())
+			    .isHerbal(drugEntity.getIsHerbal())
                 .vector(DrugMapper.parseJsonToFloatArray(embedEntity.getGptVector()))
                 .build();
     }

--- a/src/main/java/com/likelion/backendplus4/yakplus/index/infrastructure/adapter/persistence/KmBertEmbeddingLoadingAdapter.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/index/infrastructure/adapter/persistence/KmBertEmbeddingLoadingAdapter.java
@@ -1,11 +1,14 @@
 package com.likelion.backendplus4.yakplus.index.infrastructure.adapter.persistence;
 
+import com.likelion.backendplus4.yakplus.common.util.log.LogLevel;
 import com.likelion.backendplus4.yakplus.drug.domain.model.Drug;
 import com.likelion.backendplus4.yakplus.drug.infrastructure.persistence.repository.entity.DrugKmBertEmbedEntity;
 import com.likelion.backendplus4.yakplus.drug.infrastructure.persistence.repository.entity.DrugRawDataEntity;
 import com.likelion.backendplus4.yakplus.drug.infrastructure.persistence.repository.jpa.GovDrugJpaRepository;
 import com.likelion.backendplus4.yakplus.drug.infrastructure.persistence.repository.jpa.GovDrugKmBertEmbedJpaRepository;
 import com.likelion.backendplus4.yakplus.index.application.port.out.EmbeddingLoadingPort;
+import com.likelion.backendplus4.yakplus.index.exception.IndexException;
+import com.likelion.backendplus4.yakplus.index.exception.error.IndexErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.domain.Pageable;
@@ -16,29 +19,28 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.likelion.backendplus4.yakplus.common.util.log.LogUtil.log;
+
 @Repository
 @RequiredArgsConstructor
 public class KmBertEmbeddingLoadingAdapter implements EmbeddingLoadingPort {
     private final GovDrugKmBertEmbedJpaRepository govDrugKmBertEmbedJpaRepository;
-    private final GovDrugJpaRepository govDrugJpaRepository;
 
     @Override
     public List<Drug> loadEmbeddingsByPage(Pageable pageable) {
-        List<DrugRawDataEntity> rawDataEntities = govDrugJpaRepository.findAll(pageable).getContent();
-        List<DrugKmBertEmbedEntity> drugKmBertEmbedEntities = govDrugKmBertEmbedJpaRepository.findAll(pageable).getContent();
-
-        // drugKmBertEmbedEntities를 Map으로 변환 (key: drugId)
-        Map<Long, DrugKmBertEmbedEntity> kmBertEmbedMap = new HashMap<>();
-        for (DrugKmBertEmbedEntity embed : drugKmBertEmbedEntities) {
-            kmBertEmbedMap.put(embed.getDrugId(), embed);
-        }
-
         List<Drug> drugs = new ArrayList<>();
-        for (DrugRawDataEntity drugRawData : rawDataEntities) {
-            DrugKmBertEmbedEntity embed = kmBertEmbedMap.get(drugRawData.getDrugId());
-            Drug drug = toDomainFromEntity(drugRawData, embed);
-            drugs.add(drug);
+        List<Object[]> rows = govDrugKmBertEmbedJpaRepository.findRawAndEmbed(pageable);
+        log("loadEmbeddingsByPage - " + pageable.getPageNumber() +"페이지 에서 받아온 drug 객체 제작 대상 데이터 수: " + rows.size());
+        if (rows.isEmpty()) {
+            log(LogLevel.ERROR,"loadEmbeddingsByPage - Drug 도메인 객체 생성 대상 데이터 없음");
+            throw new IndexException(IndexErrorCode.RAW_DATA_FETCH_ERROR);
         }
+        for (Object[] arr : rows) {
+            DrugRawDataEntity   raw   = (DrugRawDataEntity)   arr[0];
+            DrugKmBertEmbedEntity embed = (DrugKmBertEmbedEntity)  arr[1];
+            drugs.add(toDomainFromEntity(raw, embed));
+        }
+        log("loadEmbeddingsByPage - Drug 도메인 객체 생성 완료");
 
         return drugs;
     }
@@ -57,6 +59,9 @@ public class KmBertEmbeddingLoadingAdapter implements EmbeddingLoadingPort {
                 .usage(DrugMapper.parseStringToList(drugEntity.getUsage()))
                 .precaution(DrugMapper.parsePrecaution(drugEntity.getPrecaution()))
                 .imageUrl(drugEntity.getImageUrl())
+                .cancelDate(drugEntity.getCancelDate())
+                .cancelName(drugEntity.getCancelName())
+                .isHerbal(drugEntity.getIsHerbal())
                 .vector(DrugMapper.parseJsonToFloatArray(embedEntity.getKmBertVector()))
                 .build();
     }

--- a/src/main/java/com/likelion/backendplus4/yakplus/index/infrastructure/adapter/persistence/KrSBertEmbeddingLoadingAdapter.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/index/infrastructure/adapter/persistence/KrSBertEmbeddingLoadingAdapter.java
@@ -1,11 +1,14 @@
 package com.likelion.backendplus4.yakplus.index.infrastructure.adapter.persistence;
 
+import com.likelion.backendplus4.yakplus.common.util.log.LogLevel;
 import com.likelion.backendplus4.yakplus.drug.domain.model.Drug;
 import com.likelion.backendplus4.yakplus.drug.infrastructure.persistence.repository.entity.DrugKrSbertEmbedEntity;
 import com.likelion.backendplus4.yakplus.drug.infrastructure.persistence.repository.entity.DrugRawDataEntity;
 import com.likelion.backendplus4.yakplus.drug.infrastructure.persistence.repository.jpa.GovDrugJpaRepository;
 import com.likelion.backendplus4.yakplus.drug.infrastructure.persistence.repository.jpa.GovDrugKrSbertEmbedJpaRepository;
 import com.likelion.backendplus4.yakplus.index.application.port.out.EmbeddingLoadingPort;
+import com.likelion.backendplus4.yakplus.index.exception.IndexException;
+import com.likelion.backendplus4.yakplus.index.exception.error.IndexErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.domain.Pageable;
@@ -16,29 +19,28 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.likelion.backendplus4.yakplus.common.util.log.LogUtil.log;
+
 @Repository
 @RequiredArgsConstructor
 public class KrSBertEmbeddingLoadingAdapter implements EmbeddingLoadingPort {
     private final GovDrugKrSbertEmbedJpaRepository govDrugKrSbertEmbedJpaRepository;
-    private final GovDrugJpaRepository govDrugJpaRepository;
 
     @Override
     public List<Drug> loadEmbeddingsByPage(Pageable pageable) {
-        List<DrugRawDataEntity> rawDataEntities = govDrugJpaRepository.findAll(pageable).getContent();
-        List<DrugKrSbertEmbedEntity> drugKrSBertEmbedEntities = govDrugKrSbertEmbedJpaRepository.findAll(pageable).getContent();
-
-        // drugKrSBertEmbedEntities를 Map으로 변환 (key: drugId)
-        Map<Long, DrugKrSbertEmbedEntity> krSBertEmbedMap = new HashMap<>();
-        for (DrugKrSbertEmbedEntity embed : drugKrSBertEmbedEntities) {
-            krSBertEmbedMap.put(embed.getDrugId(), embed);
-        }
-
         List<Drug> drugs = new ArrayList<>();
-        for (DrugRawDataEntity drugRawData : rawDataEntities) {
-            DrugKrSbertEmbedEntity embed = krSBertEmbedMap.get(drugRawData.getDrugId());
-            Drug drug = toDomainFromEntity(drugRawData, embed);
-            drugs.add(drug);
+        List<Object[]> rows = govDrugKrSbertEmbedJpaRepository.findRawAndEmbed(pageable);
+        log("loadEmbeddingsByPage - " + pageable.getPageNumber() +"페이지 에서 받아온 drug 객체 제작 대상 데이터 수: " + rows.size());
+        if (rows.isEmpty()) {
+            log(LogLevel.ERROR,"loadEmbeddingsByPage - Drug 도메인 객체 생성 대상 데이터 없음");
+            throw new IndexException(IndexErrorCode.RAW_DATA_FETCH_ERROR);
         }
+        for (Object[] arr : rows) {
+            DrugRawDataEntity   raw   = (DrugRawDataEntity)   arr[0];
+            DrugKrSbertEmbedEntity embed = (DrugKrSbertEmbedEntity)  arr[1];
+            drugs.add(toDomainFromEntity(raw, embed));
+        }
+        log("loadEmbeddingsByPage - Drug 도메인 객체 생성 완료");
 
         return drugs;
     }
@@ -57,6 +59,9 @@ public class KrSBertEmbeddingLoadingAdapter implements EmbeddingLoadingPort {
                 .usage(DrugMapper.parseStringToList(drugEntity.getUsage()))
                 .precaution(DrugMapper.parsePrecaution(drugEntity.getPrecaution()))
                 .imageUrl(drugEntity.getImageUrl())
+                .cancelDate(drugEntity.getCancelDate())
+                .cancelName(drugEntity.getCancelName())
+                .isHerbal(drugEntity.getIsHerbal())
                 .vector(DrugMapper.parseJsonToFloatArray(embedEntity.getKrSbertVector()))
                 .build();
     }


### PR DESCRIPTION
1. 색인 요청 시 데이터를 불러오는 EmbeddingAdapter의 동작을 수정 하였습니다.
- 기존 방식
RawData 테이블과 vector 테이블을 한페이지 씩 읽어온 후, 
서버 단에서 동일한 drugId를 가진 데이터를 Drug(도메인 객체) 로 합치는 방식.
**문제점)**
임베딩 데이터수와 Raw Data수가 일치하지 않으면, 데이터 정합성 문제 발생 (빈값이 조회되어 버리는 문제)

- 수정된 방식
DB에서 RawData 테이블과 Embedding 테이블을 JOIN 하여 조회하도록 EmbeddingAdapter 수정

2. ES 색인 요청 시, getEsIndexName 함수를 호출하면 임베딩 모델의 BeanName을 반환하도록 수정하였습니다.
#64 
