### PR TITLE
♻️  Refactor: 임베딩 저장/로딩 포트통합

### DIFF
--- a/src/main/java/com/likelion/backendplus4/yakplus/drug/presentation/controller/DrugDataTestController.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/drug/presentation/controller/DrugDataTestController.java
@@ -10,12 +10,10 @@ import org.springframework.web.bind.annotation.RestController;
 import com.likelion.backendplus4.yakplus.drug.application.service.port.in.DrugCombineUsecase;
 import com.likelion.backendplus4.yakplus.drug.application.service.port.in.DrugEmbedProcessorUseCase;
 import com.likelion.backendplus4.yakplus.drug.application.service.scraper.DrugScraper;
-import com.likelion.backendplus4.yakplus.drug.application.service.port.out.EmbeddingPort;
 
 import lombok.RequiredArgsConstructor;
 
 import com.likelion.backendplus4.yakplus.drug.infrastructure.embedding.model.EmbeddingModelType;
-import com.likelion.backendplus4.yakplus.response.ApiResponse;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/likelion/backendplus4/yakplus/index/application/port/out/EmbeddingLoadingPort.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/index/application/port/out/EmbeddingLoadingPort.java
@@ -7,4 +7,8 @@ import java.util.List;
 
 public interface EmbeddingLoadingPort {
     List<Drug> loadEmbeddingsByPage(Pageable pageable);
+
+    float[] getEmbedding(String text);
+
+    void saveEmbedding(Long drugId, float[] embedding);
 }

--- a/src/main/java/com/likelion/backendplus4/yakplus/index/application/port/out/GovDrugRawDataPort.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/index/application/port/out/GovDrugRawDataPort.java
@@ -7,8 +7,9 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface GovDrugRawDataPort {
-    List<Drug> fetchRawData(int i);
+    List<Drug> fetchRawData(int pageNo, int numOfRows);
 
     Page<Drug> findAllDrugs(Pageable pageable);
 
+    long getDrugTotalSize();
 }

--- a/src/main/java/com/likelion/backendplus4/yakplus/index/infrastructure/adapter/persistence/GovDrugRawDataAdapter.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/index/infrastructure/adapter/persistence/GovDrugRawDataAdapter.java
@@ -37,10 +37,6 @@ public class GovDrugRawDataAdapter implements GovDrugRawDataPort {
     private final GovDrugJpaRepository drugJpaRepository;
     private final EmbeddingLoadingPort embeddingLoadingPort;
 
-    @Value("${gov.numOfRows}")
-    private int numOfRows;
-
-
 
     /**
      * 주어진 Pageable 정보에 따라 DB에서 한 페이지 분량의 GovDrugEntity를 조회하고,
@@ -131,15 +127,29 @@ public class GovDrugRawDataAdapter implements GovDrugRawDataPort {
 
 
     @Override
-    public List<Drug> fetchRawData(int pageNo) {
+    public List<Drug> fetchRawData(int pageNo, int numOfRows) {
         log("index 서비스 요청 수신");
-        Pageable pageable = createPageable(pageNo);
+        Pageable pageable = createPageable(pageNo, numOfRows);
         List<Drug> drugs = embeddingLoadingPort.loadEmbeddingsByPage(pageable);
         return drugs;
     }
 
-    private Pageable createPageable(int pageNo) {
+    private Pageable createPageable(int pageNo, int numOfRows) {
         log("pageable 생성");
         return PageRequest.of(pageNo, numOfRows, Sort.by(Sort.Direction.ASC, "drugId"));
+    }
+
+
+    /**
+     * JPA 레포지토리를 이용해 GovDrugJpaRepository의 전체 데이터 수를 조회합니다.
+     *
+     * @return GovDrugJpaRepository의 전체 데이터 수
+     * @author 이해창
+     * @since 2025-05-02
+     * @modified
+     */
+    @Override
+    public long getDrugTotalSize() {
+        return drugJpaRepository.count();
     }
 }

--- a/src/main/java/com/likelion/backendplus4/yakplus/index/infrastructure/adapter/persistence/GptEmbeddingLoadingAdapter.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/index/infrastructure/adapter/persistence/GptEmbeddingLoadingAdapter.java
@@ -1,23 +1,29 @@
 package com.likelion.backendplus4.yakplus.index.infrastructure.adapter.persistence;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.likelion.backendplus4.yakplus.common.util.log.LogLevel;
 import com.likelion.backendplus4.yakplus.drug.domain.model.Drug;
 import com.likelion.backendplus4.yakplus.drug.infrastructure.persistence.repository.entity.DrugGptEmbedEntity;
 import com.likelion.backendplus4.yakplus.drug.infrastructure.persistence.repository.entity.DrugRawDataEntity;
 import com.likelion.backendplus4.yakplus.drug.infrastructure.persistence.repository.jpa.GovDrugGptEmbedJpaRepository;
-import com.likelion.backendplus4.yakplus.drug.infrastructure.persistence.repository.jpa.GovDrugJpaRepository;
 import com.likelion.backendplus4.yakplus.index.application.port.out.EmbeddingLoadingPort;
 import com.likelion.backendplus4.yakplus.index.exception.IndexException;
 import com.likelion.backendplus4.yakplus.index.exception.error.IndexErrorCode;
+import com.likelion.backendplus4.yakplus.index.support.EmbeddingUtil.EmbedEntityBuilder;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Primary;
+import org.springframework.ai.document.MetadataMode;
+import org.springframework.ai.embedding.Embedding;
+import org.springframework.ai.embedding.EmbeddingResponse;
+import org.springframework.ai.openai.OpenAiEmbeddingModel;
+import org.springframework.ai.openai.OpenAiEmbeddingOptions;
+import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.ai.retry.RetryUtils;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static com.likelion.backendplus4.yakplus.common.util.log.LogUtil.log;
 
@@ -25,23 +31,44 @@ import static com.likelion.backendplus4.yakplus.common.util.log.LogUtil.log;
 @RequiredArgsConstructor
 public class GptEmbeddingLoadingAdapter implements EmbeddingLoadingPort {
     private final GovDrugGptEmbedJpaRepository govDrugGptEmbedJpaRepository;
+    private final OpenAiApi openAiApi;
 
     @Override
     public List<Drug> loadEmbeddingsByPage(Pageable pageable) {
         List<Drug> drugs = new ArrayList<>();
         List<Object[]> rows = govDrugGptEmbedJpaRepository.findRawAndEmbed(pageable);
-        log("loadEmbeddingsByPage - " + pageable.getPageNumber() +"페이지 에서 받아온 drug 객체 제작 대상 데이터 수: " + rows.size());
+        log("loadEmbeddingsByPage - " + pageable.getPageNumber() + "페이지 에서 받아온 drug 객체 제작 대상 데이터 수: " + rows.size());
         if (rows.isEmpty()) {
-            log(LogLevel.ERROR,"loadEmbeddingsByPage - Drug 도메인 객체 생성 대상 데이터 없음");
+            log(LogLevel.ERROR, "loadEmbeddingsByPage - Drug 도메인 객체 생성 대상 데이터 없음");
             throw new IndexException(IndexErrorCode.RAW_DATA_FETCH_ERROR);
         }
         for (Object[] arr : rows) {
-            DrugRawDataEntity   raw   = (DrugRawDataEntity)   arr[0];
-            DrugGptEmbedEntity  embed = (DrugGptEmbedEntity)  arr[1];
+            DrugRawDataEntity raw = (DrugRawDataEntity) arr[0];
+            DrugGptEmbedEntity embed = (DrugGptEmbedEntity) arr[1];
             drugs.add(toDomainFromEntity(raw, embed));
         }
         log("loadEmbeddingsByPage - Drug 도메인 객체 생성 완료");
         return drugs;
+    }
+
+    @Override
+    public float[] getEmbedding(String text) {
+        OpenAiEmbeddingModel openAiEmbeddingModel = new OpenAiEmbeddingModel(
+                this.openAiApi,
+                MetadataMode.EMBED,
+                OpenAiEmbeddingOptions.builder()
+                        .model("text-embedding-3-small")
+                        .build(),
+                RetryUtils.DEFAULT_RETRY_TEMPLATE);
+        EmbeddingResponse embeddingResponse = openAiEmbeddingModel
+                .embedForResponse(List.of(text));
+        Embedding embedding = embeddingResponse.getResults().getFirst();
+        return embedding.getOutput();
+    }
+
+    @Override
+    public void saveEmbedding(Long drugId, float[] embedding) {
+        govDrugGptEmbedJpaRepository.save(EmbedEntityBuilder.buildEmbedEntity(drugId, embedding, DrugGptEmbedEntity.class));
     }
 
     private static Drug toDomainFromEntity(DrugRawDataEntity drugEntity, DrugGptEmbedEntity embedEntity) {
@@ -59,12 +86,11 @@ public class GptEmbeddingLoadingAdapter implements EmbeddingLoadingPort {
                 .precaution(DrugMapper.parsePrecaution(drugEntity.getPrecaution()))
                 .imageUrl(drugEntity.getImageUrl())
                 .cancelDate(drugEntity.getCancelDate())
-			    .cancelName(drugEntity.getCancelName())
-			    .isHerbal(drugEntity.getIsHerbal())
+                .cancelName(drugEntity.getCancelName())
+                .isHerbal(drugEntity.getIsHerbal())
                 .vector(DrugMapper.parseJsonToFloatArray(embedEntity.getGptVector()))
                 .build();
     }
-
 
 
 }

--- a/src/main/java/com/likelion/backendplus4/yakplus/index/support/EmbeddingUtil/EmbedEntityBuilder.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/index/support/EmbeddingUtil/EmbedEntityBuilder.java
@@ -1,0 +1,27 @@
+package com.likelion.backendplus4.yakplus.index.support.EmbeddingUtil;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class EmbedEntityBuilder {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    public static <T> T buildEmbedEntity(Long drugId, float[] vector, Class<T> clazz) {
+        try {
+            return clazz.getDeclaredConstructor(Long.class, String.class)
+                    .newInstance(drugId, toStringFromFloatArray(vector));
+        } catch (Exception e) {
+            //TODO: 엔터티 생성 실패
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static String toStringFromFloatArray(float[] vector) {
+        try {
+            return MAPPER.writeValueAsString(vector);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/likelion/backendplus4/yakplus/switcher/infrastructure/route/adapter/EmbeddingRouterAdapter.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/switcher/infrastructure/route/adapter/EmbeddingRouterAdapter.java
@@ -60,4 +60,22 @@ public class EmbeddingRouterAdapter implements EmbeddingLoadingPort, EmbeddingSw
         log("어댑터 빈 이름 요청 - 현재 선택된 어댑터: " + adapterBeanName);
         return adapterBeanName;
     }
+
+    @Override
+    public float[] getEmbedding(String text) {
+        if (embeddingLoadingPort == null) {
+            log(LogLevel.ERROR, "임베딩 어댑터가 선택되지 않았습니다.");
+            throw new IllegalStateException("No adapter selected");
+        }
+        return embeddingLoadingPort.getEmbedding(text);
+    }
+
+    @Override
+    public void saveEmbedding(Long drugId, float[] embedding) {
+        if (embeddingLoadingPort == null) {
+            log(LogLevel.ERROR, "임베딩 어댑터가 선택되지 않았습니다.");
+            throw new IllegalStateException("No adapter selected");
+        }
+        embeddingLoadingPort.saveEmbedding(drugId, embedding);
+    }
 }


### PR DESCRIPTION
임베딩 모델 지정을 EmbeddingPort 와 EmbeddingLoadingPort 에서 각기 다른 방식을 사용하고 있었는데,
EmbeddingLoadingPort에서 모델을 런타임에 교체하는 로직을 구현해 주심에 따라, EmbeddingLoadingPort로 통합하였습니다.

포트 통합에 따른 각 모델 어뎁터로의 메서드 이동이 있었으며, 
벡터를 RDB에 저장할 시에 entity를 만들어주는 공통 로직은 /index/support/EmbeddingUtil/EmbedEntityBuilder 로 이동하였습니다.

#66 